### PR TITLE
PLAT-752: Fix changelog assumption

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,14 @@ const parser = yargs(process.argv.slice(2))
 
 (async () => {
   const { format, path, depName, newVersion, currentVersion, ignoreFailure } = await parser.argv;
+  
+  try {
+    await fs.access(path);
+  } catch (e) {
+    console.error('CHANGELOG.md not found. Exiting.');
+    process.exit(1);
+  }
+  
   let changelogBuffer;
   try {
     changelogBuffer = await fs.readFile(path);

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const parser = yargs(process.argv.slice(2))
   .example('$0 --dep-name my-updated-package --current-version 1.0.0 --new-version 2.0.0 --is-lock-file-maintenance false', '');
 
 (async () => {
-  const { format, path, depName, newVersion, currentVersion, ignoreFailure } = await parser.argv;
+  const { format, path, depName, newVersion, currentVersion, isLockFileMaintenance, ignoreFailure } = await parser.argv;
   
   try {
     await fs.access(path);

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ const parser = yargs(process.argv.slice(2))
     await fs.access(path);
   } catch (e) {
     console.error('CHANGELOG.md not found. Exiting.');
-    process.exit(1);
+    process.exit(0);
   }
   
   let changelogBuffer;


### PR DESCRIPTION
Previously, Renovate did not allow for a changelog to not exist when processing a repository. This change will permit the absence of a CHANGELOG.md file and exit cleanly without doing any work if one is not present.